### PR TITLE
Fix GetOrientation

### DIFF
--- a/EarClipperLib/Misc.cs
+++ b/EarClipperLib/Misc.cs
@@ -15,9 +15,7 @@ namespace EarClipperLib
             var res = (v0 - v1).Cross(v2 - v1);
             if (res.LengthSquared() == 0)
                 return 0;
-            if (res.X.Sign != normal.X.Sign || res.Y.Sign != normal.Y.Sign || res.Z.Sign != normal.Z.Sign)
-                return 1;
-            return -1;
+            return -res.Dot(normal).Sign;
         }
 
         // Is testPoint between a and b in ccw order?


### PR DESCRIPTION
There is a Problem in GetOrientation when the Normal is Suppsed to have one Coordinate 0, but due to floating point Input Coordinates the points are slightly non coplanar. and this the Normal has a axis value of eg 0.0000001... instead of 0.
This leads to the sign beeing unequal In cases where Crossproduct is exactly 0 but the normal not.
I switched logic to test the sign of the crossproduct and thus allow for errors in the normal 